### PR TITLE
Fix README to download model referenced in code

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ git clone --depth=1 --recurse-submodules https://github.com/shubham0204/llama.cp
 cd llama.cpp-simple-chat-interface
 
 # download model
-wget https://huggingface.co/HuggingFaceTB/SmolLM2-360M-Instruct-GGUF/resolve/main/smollm2-360m-instruct-q8_0.gguf -P models
+wget https://huggingface.co/bartowski/DeepSeek-R1-Distill-Qwen-1.5B-GGUF/resolve/main/DeepSeek-R1-Distill-Qwen-1.5B-Q8_0.gguf -P models
 
 # build the executable
 mkdir build


### PR DESCRIPTION
The code references DeepSeek model but README downloads a different model.  This PR updates the README to match the code.